### PR TITLE
Zoom to provided annotation

### DIFF
--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -12,7 +12,6 @@ zoomAnno = function(annoId) {
     var anno = searchAnno(annoId);
     if (anno != null) {
         var fragment = anno.on[0].selector.default.value;
-        console.debug(fragment);
         var parts = fragment.slice(5).split(',');
         mir.eventEmitter.publish('fitBounds.the_window', {'x': parts[0], 'y': parts[1], 'width': parts[2], 'height': parts[3]});
     }
@@ -55,7 +54,9 @@ $(function() {
             }
         }
     });
-    mir.eventEmitter.subscribe('windowAdded', function(data) {
+    mir.eventEmitter.subscribe('annotationListLoaded.the_window', function(data) {
+        console.log(data);
+        console.log(mir.viewer.workspace);
         var parsedUrl = new URL(window.location.href);
         var param = parsedUrl.searchParams.get("anno");
         if (param != null) {
@@ -66,4 +67,5 @@ $(function() {
             }
         }
     });
+    
 });

--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -62,6 +62,9 @@ $(function() {
     mir.eventEmitter.subscribe('imageBoundsUpdated', function(event, options) {
         console.debug('imageBoundsUpdated:', options);
     });
+    mir.eventEmitter.subscribe('imageRectUpdated', function(event, options) {
+        console.debug('imageRectUpdated:', options);
+    });
     mir.eventEmitter.subscribe('annotationListLoaded.the_window', function(data) {
         // console.log(data);
         // console.log(mir.viewer.workspace);

--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -15,7 +15,7 @@ zoomAnno = function(annoId) {
         var fragment = anno.on[0].selector.default.value;
         console.log(fragment);
         var parts = fragment.slice(5).split(',');
-        mir.eventEmitter.publish('fitBounds.the_window', {'x': parts[0], 'y': parts[1], 'width': parts[2], 'height': parts[3]});
+        mir.eventEmitter.publish('fitBounds.the_window', {'x': parseInt(parts[0]), 'y': parseInt(parts[1]), 'width': parseInt(parts[2]), 'height': parseInt(parts[3])});
     }
 }
 $(function() {

--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -11,7 +11,9 @@ searchAnno = function(annoId) {
 zoomAnno = function(annoId) {
     var anno = searchAnno(annoId);
     if (anno != null) {
+        console.debug(anno);
         var fragment = anno.on[0].selector.default.value;
+        console.log(fragment);
         var parts = fragment.slice(5).split(',');
         mir.eventEmitter.publish('fitBounds.the_window', {'x': parts[0], 'y': parts[1], 'width': parts[2], 'height': parts[3]});
     }
@@ -53,6 +55,12 @@ $(function() {
                 userrole: my_object.userrole,
             }
         }
+    });
+    mir.eventEmitter.subscribe('fitBounds.the_window', function(event, bounds) {
+        console.debug('fitBounds:', bounds);
+    });
+    mir.eventEmitter.subscribe('imageBoundsUpdated', function(event, options) {
+        console.debug('imageBoundsUpdated:', options);
     });
     mir.eventEmitter.subscribe('annotationListLoaded.the_window', function(data) {
         // console.log(data);

--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -1,4 +1,21 @@
 var mir;
+searchAnno = function(annoId) {
+    var annotations = mir.viewer.workspace.slots[0].window.annotationsList.filter(function(item) {return item.fullId === annoId;});
+    if (annotations.length > 0) {
+        return annotations[0];
+    } else {
+        return null;
+    }
+}
+
+zoomAnno = function(annoId) {
+    var anno = searchAnno(annoId);
+    if (anno != null) {
+        var fragment = anno.on[0].selector.default.value;
+        var parts = fragment.slice(5).split(',');
+        mir.eventEmitter.publish('fitBounds.the_window', {'x': parts[0], 'y': parts[1], 'width': parts[2], 'height': parts[3]});
+    }
+}
 $(function() {
     mir = Mirador({
         id: "viewer",
@@ -37,4 +54,13 @@ $(function() {
             }
         }
     });
+    var parsedUrl = new URL(window.location.href);
+    var param = parsedUrl.searchParams.get("anno");
+    if (param != null) {
+        try {
+            zoomAnno(param);
+        } catch (error) {
+            console.error(error);
+        }
+    }
 });

--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -12,6 +12,7 @@ zoomAnno = function(annoId) {
     var anno = searchAnno(annoId);
     if (anno != null) {
         var fragment = anno.on[0].selector.default.value;
+        console.debug(fragment);
         var parts = fragment.slice(5).split(',');
         mir.eventEmitter.publish('fitBounds.the_window', {'x': parts[0], 'y': parts[1], 'width': parts[2], 'height': parts[3]});
     }
@@ -54,9 +55,7 @@ $(function() {
             }
         }
     });
-    mir.eventEmitter.subscribe('annotationListLoaded.the_window', function(data) {
-        console.log(data);
-        console.log(mir.viewer.workspace);
+    mir.eventEmitter.subscribe('windowAdded', function(data) {
         var parsedUrl = new URL(window.location.href);
         var param = parsedUrl.searchParams.get("anno");
         if (param != null) {
@@ -67,5 +66,4 @@ $(function() {
             }
         }
     });
-    
 });

--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -56,7 +56,6 @@ $(function() {
         }
     });
     mir.eventEmitter.subscribe('windowAdded', function(data) {
-        console.debug('Window added', data);
         var parsedUrl = new URL(window.location.href);
         var param = parsedUrl.searchParams.get("anno");
         if (param != null) {

--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -56,6 +56,7 @@ $(function() {
         }
     });
     mir.eventEmitter.subscribe('windowAdded', function(data) {
+        console.debug('Window added', data);
         var parsedUrl = new URL(window.location.href);
         var param = parsedUrl.searchParams.get("anno");
         if (param != null) {

--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -54,17 +54,18 @@ $(function() {
             }
         }
     });
-    mir.eventEmitter.subscribe('windowAdded', function(data) {
+    mir.eventEmitter.subscribe('annotationListLoaded.the_window', function(data) {
         console.log(data);
         console.log(mir.viewer.workspace);
-    });
-    var parsedUrl = new URL(window.location.href);
-    var param = parsedUrl.searchParams.get("anno");
-    if (param != null) {
-        try {
-            zoomAnno(param);
-        } catch (error) {
-            console.error(error);
+        var parsedUrl = new URL(window.location.href);
+        var param = parsedUrl.searchParams.get("anno");
+        if (param != null) {
+            try {
+                zoomAnno(param);
+            } catch (error) {
+                console.error(error);
+            }
         }
-    }
+    });
+    
 });

--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -54,6 +54,10 @@ $(function() {
             }
         }
     });
+    mir.eventEmitter.subscribe('windowAdded', function(data) {
+        console.log(data);
+        console.log(mir.viewer.workspace);
+    });
     var parsedUrl = new URL(window.location.href);
     var param = parsedUrl.searchParams.get("anno");
     if (param != null) {

--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -55,8 +55,8 @@ $(function() {
         }
     });
     mir.eventEmitter.subscribe('annotationListLoaded.the_window', function(data) {
-        console.log(data);
-        console.log(mir.viewer.workspace);
+        // console.log(data);
+        // console.log(mir.viewer.workspace);
         var parsedUrl = new URL(window.location.href);
         var param = parsedUrl.searchParams.get("anno");
         if (param != null) {

--- a/assets/js/mirador-config.js
+++ b/assets/js/mirador-config.js
@@ -13,7 +13,7 @@ zoomAnno = function(annoId) {
     if (anno != null) {
         console.debug(anno);
         var fragment = anno.on[0].selector.default.value;
-        console.log(fragment);
+        console.debug('Canvas fragment targeted by annotation:', fragment);
         var parts = fragment.slice(5).split(',');
         mir.eventEmitter.publish('fitBounds.the_window', {'x': parseInt(parts[0]), 'y': parseInt(parts[1]), 'width': parseInt(parts[2]), 'height': parseInt(parts[3])});
     }
@@ -56,18 +56,7 @@ $(function() {
             }
         }
     });
-    mir.eventEmitter.subscribe('fitBounds.the_window', function(event, bounds) {
-        console.debug('fitBounds:', bounds);
-    });
-    mir.eventEmitter.subscribe('imageBoundsUpdated', function(event, options) {
-        console.debug('imageBoundsUpdated:', options);
-    });
-    mir.eventEmitter.subscribe('imageRectUpdated', function(event, options) {
-        console.debug('imageRectUpdated:', options);
-    });
     mir.eventEmitter.subscribe('annotationListLoaded.the_window', function(data) {
-        // console.log(data);
-        // console.log(mir.viewer.workspace);
         var parsedUrl = new URL(window.location.href);
         var param = parsedUrl.searchParams.get("anno");
         if (param != null) {


### PR DESCRIPTION
After loading, Mirador uses the URI of an annotation provided in the `anno` query parameter to look up the annotation in its list of annotations (so the URI is not dereferenced), find its bounds and zoom and pan to those bounds.

It works for our use case, in which the annotation has a choice selector in the target.