### PR TITLE
Add registration and log in/out links to menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,8 +20,12 @@ function abhier_theme_enqueue_styles() {
 }
 add_action( 'wp_enqueue_scripts', 'abhier_theme_enqueue_styles' );
 
-add_filter( 'wp_nav_menu_items', 'abhier_theme_login_register_link' );
+add_filter( 'wp_nav_menu_items', 'abhier_theme_login_register_link', 16, 2 );
 
+/**
+ * Add links to registration and log in, or site admin and log out
+ * in the menu. The function should be called late and receive two arguments.
+ */
 function abhier_theme_login_register_link($menu_items, $args) {
     // add the login or register URL
     $menu_items .= wp_register('<li class="menu-item">', '</li>', false);

--- a/functions.php
+++ b/functions.php
@@ -19,4 +19,13 @@ function abhier_theme_enqueue_styles() {
     }
 }
 add_action( 'wp_enqueue_scripts', 'abhier_theme_enqueue_styles' );
-?>
+
+add_filter( 'wp_nav_menu_items', 'abhier_theme_login_register_link' );
+
+function abhier_theme_login_register_link($menu_items, $args) {
+    // add the login or register URL
+    $menu_items .= wp_register('<li class="menu-item">', '</li>', false);
+    $menu_items .= '<li class="menu-item">'
+        . wp_loginout( $_SERVER['REQUEST_URI'], false )
+        . '</li>';
+}

--- a/functions.php
+++ b/functions.php
@@ -28,4 +28,5 @@ function abhier_theme_login_register_link($menu_items, $args) {
     $menu_items .= '<li class="menu-item">'
         . wp_loginout( $_SERVER['REQUEST_URI'], false )
         . '</li>';
+    return $menu_items;
 }

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Ben Companjen
  Author URI:   https://orcid.org/0000-0002-7023-9047
  Template:     modern
- Version:      1.4.0
+ Version:      1.5.0
  License:      GNU General Public License v2 or later
  License URI:  http://www.gnu.org/licenses/gpl-2.0.html
  Tags:         dark, one-column, responsive-layout, accessibility-ready


### PR DESCRIPTION
When not logged in, a link to registration (when registration is allowed) and a log in link are added to the menu. If logged in, these links point to the administration page and the log out 'page'.